### PR TITLE
Allow starting from step zero

### DIFF
--- a/src/components/StepMetroBreadcrumb.tsx
+++ b/src/components/StepMetroBreadcrumb.tsx
@@ -2,7 +2,12 @@ import React from "react";
 
 export interface StepMetroBreadcrumbProps {
   steps: string[];
-  currentStep: number; // 0-based index
+  /**
+   * Position courante.
+   * 0 indique qu'aucune étape n'est encore démarrée.
+   * 1 correspond à la première étape, etc.
+   */
+  currentStep: number;
   circleSize?: number; // diamètre en px (optionnel, défaut 40)
   itemWidth?: number; // largeur d'un item (optionnel, défaut 128)
 }
@@ -32,35 +37,41 @@ export const StepMetroBreadcrumb: React.FC<StepMetroBreadcrumbProps> = ({
       />
       {/* Les étapes */}
       <div className="flex w-full justify-start z-10">
-        {steps.map((step, idx) => (
-          <div
-            key={idx}
-            className="flex flex-col items-center"
-            style={{ minWidth: itemWidth, width: itemWidth }}
-          >
+        {steps.map((step, idx) => {
+          const stepNumber = idx + 1;
+          const isCompleted = currentStep > stepNumber;
+          const isCurrent = currentStep === stepNumber;
+
+          return (
             <div
-              className={[
-                "flex items-center justify-center rounded-full border-2 font-bold",
-                idx < currentStep
-                  ? "bg-green-500 border-green-500 text-white"
-                  : idx === currentStep
-                  ? "bg-blue-500 border-blue-500 text-white"
-                  : "bg-gray-200 border-gray-300 text-gray-500",
-              ].join(" ")}
-              style={{
-                width: circleSize,
-                height: circleSize,
-                fontSize: circleSize / 2,
-                zIndex: 1,
-              }}
+              key={idx}
+              className="flex flex-col items-center"
+              style={{ minWidth: itemWidth, width: itemWidth }}
             >
-              {idx < currentStep ? "✓" : idx + 1}
+              <div
+                className={[
+                  "flex items-center justify-center rounded-full border-2 font-bold",
+                  isCompleted
+                    ? "bg-green-500 border-green-500 text-white"
+                    : isCurrent
+                    ? "bg-blue-500 border-blue-500 text-white"
+                    : "bg-gray-200 border-gray-300 text-gray-500",
+                ].join(" ")}
+                style={{
+                  width: circleSize,
+                  height: circleSize,
+                  fontSize: circleSize / 2,
+                  zIndex: 1,
+                }}
+              >
+                {isCompleted ? "✓" : stepNumber}
+              </div>
+              <span className="flex items-center justify-center mt-2 text-sm font-semibold w-full break-words h-8 text-center p-4">
+                {step}
+              </span>
             </div>
-            <span className="flex items-center justify-center mt-2 text-sm font-semibold w-full break-words h-8 text-center p-4">
-              {step}
-            </span>
-          </div>
-        ))}
+          );
+        })}
       </div>
     </div>
   );

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { StepMetroBreadcrumb } from "../components/StepMetroBreadcrumb";
 
 export default function Home() {
-  const [currentStep, setCurrentStep] = useState(2); // exemple : étape 3 en cours (0-based)
+  const [currentStep, setCurrentStep] = useState(0); // 0 : aucune étape franchie
   const steps = [
     "Charger les données",
     "Séparer les données",
@@ -16,20 +16,31 @@ export default function Home() {
       <div className="p-6 max-w-3xl mx-auto">
         <StepMetroBreadcrumb steps={steps} currentStep={currentStep} />
         <div className="mt-6 flex gap-2 justify-center">
-          <button
-            className="px-4 py-2 bg-gray-200 rounded"
-            onClick={() => setCurrentStep((s) => Math.max(0, s - 1))}
-          >
-            Précédent
-          </button>
-          <button
-            className="px-4 py-2 bg-blue-500 text-white rounded"
-            onClick={() =>
-              setCurrentStep((s) => Math.min(steps.length - 1, s + 1))
-            }
-          >
-            Suivant
-          </button>
+          {currentStep === 0 ? (
+            <button
+              className="px-4 py-2 bg-blue-500 text-white rounded"
+              onClick={() => setCurrentStep(1)}
+            >
+              Getting Started
+            </button>
+          ) : (
+            <>
+              <button
+                className="px-4 py-2 bg-gray-200 rounded"
+                onClick={() => setCurrentStep((s) => Math.max(0, s - 1))}
+              >
+                Précédent
+              </button>
+              <button
+                className="px-4 py-2 bg-blue-500 text-white rounded"
+                onClick={() =>
+                  setCurrentStep((s) => Math.min(steps.length, s + 1))
+                }
+              >
+                Suivant
+              </button>
+            </>
+          )}
         </div>
       </div>
     </>


### PR DESCRIPTION
## Summary
- handle `currentStep` of 0 in `StepMetroBreadcrumb`
- show `Getting Started` button before first step

## Testing
- `pnpm lint`
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_68442f2e8be88325952c63f7e14f10e4