### PR TITLE
Refactor Playground state handling

### DIFF
--- a/src/pages/Playground.tsx
+++ b/src/pages/Playground.tsx
@@ -1,5 +1,5 @@
 import { ModelStoragePanel } from "../components/ModelStoragePanel";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import * as tf from "@tensorflow/tfjs";
 import { useMLPStore } from "../stores/useMLPStore";
 import { CanvasInput } from "../components/CanvasInput";
@@ -25,16 +25,13 @@ export default function Playground() {
   const resetHistory = useMLPStore((s) => s.resetHistory);
   const resetAll = useMLPStore((s) => s.resetAll);
 
-  const [structure, setStructure] = useState<number[]>([]);
+  const structure = useMLPStore((s) => s.structure);
+  const setStructure = useMLPStore((s) => s.setStructure);
 
-  const [trainData, setTrainData] = useState<{
-    xs: tf.Tensor;
-    ys: tf.Tensor;
-  } | null>(null);
-  const [testData, setTestData] = useState<{
-    xs: tf.Tensor;
-    ys: tf.Tensor;
-  } | null>(null);
+  const trainData = useMLPStore((s) => s.trainData);
+  const testData = useMLPStore((s) => s.testData);
+  const setTrainData = useMLPStore((s) => s.setTrainData);
+  const setTestData = useMLPStore((s) => s.setTestData);
 
   // Charger les données (par ex depuis digits_8x8.json)
   useEffect(() => {

--- a/src/stores/useMLPStore.ts
+++ b/src/stores/useMLPStore.ts
@@ -12,12 +12,19 @@ export interface TrainingHistory {
 interface MLPStore {
   model: tf.LayersModel | null;
   layers: number[];
+  /** layer sizes extracted from the current model */
+  structure: number[];
   pixels: number[];
+  trainData: { xs: tf.Tensor; ys: tf.Tensor } | null;
+  testData: { xs: tf.Tensor; ys: tf.Tensor } | null;
   training: boolean;
   trainingHistory: TrainingHistory;
   setModel: (model: tf.LayersModel) => void;
   setLayers: (layers: number[]) => void;
+  setStructure: (structure: number[]) => void;
   setPixels: (pixels: number[]) => void;
+  setTrainData: (data: { xs: tf.Tensor; ys: tf.Tensor } | null) => void;
+  setTestData: (data: { xs: tf.Tensor; ys: tf.Tensor } | null) => void;
   setTraining: (v: boolean) => void;
   resetHistory: () => void;
   updateHistory: (epoch: number, logs: tf.Logs) => void;
@@ -27,7 +34,10 @@ interface MLPStore {
 export const useMLPStore = create<MLPStore>((set) => ({
   model: null,
   layers: [32, 16],
+  structure: [],
   pixels: [],
+  trainData: null,
+  testData: null,
   training: false,
   trainingHistory: {
     epochs: [],
@@ -38,7 +48,10 @@ export const useMLPStore = create<MLPStore>((set) => ({
   },
   setModel: (model) => set({ model }),
   setLayers: (layers) => set({ layers }),
+  setStructure: (structure) => set({ structure }),
   setPixels: (pixels) => set({ pixels }),
+  setTrainData: (data) => set({ trainData: data }),
+  setTestData: (data) => set({ testData: data }),
   setTraining: (v) => set({ training: v }),
   resetHistory: () =>
     set({
@@ -64,6 +77,7 @@ export const useMLPStore = create<MLPStore>((set) => ({
     set({
       model: null,
       layers: [32, 16],
+      structure: [],
       pixels: [],
       training: false,
       trainingHistory: {


### PR DESCRIPTION
## Summary
- centralize Playground state in `useMLPStore`
- expose structure and dataset from zustand store

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68455fd4d5708325b996dc123e35bb21