### PR TITLE
Refactor training components

### DIFF
--- a/src/components/TrainingChart.tsx
+++ b/src/components/TrainingChart.tsx
@@ -10,6 +10,7 @@ import {
   Legend,
   Tooltip,
 } from "chart.js";
+import { useMLPStore } from "../stores/useMLPStore";
 
 ChartJS.register(
   LineElement,
@@ -21,17 +22,8 @@ ChartJS.register(
   Tooltip
 );
 
-type Props = {
-  history: {
-    epochs: number[];
-    loss: number[];
-    valLoss: number[];
-    accuracy: number[];
-    valAccuracy: number[];
-  };
-};
-
-export const TrainingChart: React.FC<Props> = ({ history }) => {
+export const TrainingChart: React.FC = () => {
+  const history = useMLPStore((s) => s.trainingHistory);
   const data = {
     labels: history.epochs,
     datasets: [

--- a/src/components/TrainingPanel.tsx
+++ b/src/components/TrainingPanel.tsx
@@ -2,17 +2,10 @@ import React, { useState } from "react";
 import * as tf from "@tensorflow/tfjs";
 import { useMLPStore } from "../stores/useMLPStore";
 
-type Props = {
-  model: tf.LayersModel;
-  trainData: { xs: tf.Tensor; ys: tf.Tensor };
-  testData: { xs: tf.Tensor; ys: tf.Tensor };
-};
-
-export const TrainingPanel: React.FC<Props> = ({
-  model,
-  trainData,
-  testData,
-}) => {
+export const TrainingPanel: React.FC = () => {
+  const model = useMLPStore((s) => s.model);
+  const trainData = useMLPStore((s) => s.trainData);
+  const testData = useMLPStore((s) => s.testData);
   const [learningRate, setLearningRate] = useState(0.01);
   const [epochs, setEpochs] = useState(10);
   const [batchSize, setBatchSize] = useState(32);
@@ -22,6 +15,7 @@ export const TrainingPanel: React.FC<Props> = ({
   const updateHistory = useMLPStore((s) => s.updateHistory);
 
   const startTraining = async () => {
+    if (!model || !trainData || !testData) return;
     setTraining(true);
 
     model.compile({

--- a/src/pages/Playground.tsx
+++ b/src/pages/Playground.tsx
@@ -96,16 +96,8 @@ export default function Playground() {
           <ModelStoragePanel />
         </>
       )}
-      {model && trainData && testData && (
-        <TrainingPanel
-          model={model}
-          trainData={trainData}
-          testData={testData}
-        />
-      )}
-      {trainingHistory.epochs.length > 0 && (
-        <TrainingChart history={trainingHistory} />
-      )}
+      {model && trainData && testData && <TrainingPanel />}
+      {trainingHistory.epochs.length > 0 && <TrainingChart />}
 
       <CanvasInput />
       <PredictPanel />


### PR DESCRIPTION
## Summary
- pull training parameters and history directly from zustand store
- simplify usage of TrainingPanel and TrainingChart

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_684563cbec288325ab23e4d056208dfc