### PR TITLE
Refactor MLPGraph to use store

### DIFF
--- a/src/components/MLPGraph.tsx
+++ b/src/components/MLPGraph.tsx
@@ -1,19 +1,16 @@
 import React from "react";
+import { useMLPStore } from "../stores/useMLPStore";
 
-interface Props {
-  layers: number[];
-  activations?: number[][];
-}
+export const MLPGraph: React.FC = () => {
+  const structure = useMLPStore((s) => s.structure);
+  const layers = [64, ...structure];
 
-export const MLPGraph: React.FC<Props> = ({ layers, activations }) => {
   return (
     <svg viewBox="0 0 600 400" className="w-full h-96 bg-white">
-      {layers.map((count, layerIndex) => {
-        return Array.from({ length: count }).map((_, i) => {
+      {layers.map((count, layerIndex) =>
+        Array.from({ length: count }).map((_, i) => {
           const x = 100 + layerIndex * 120;
           const y = count > 1 ? 50 + (i * 300) / (count - 1) : 200;
-          const activation = activations?.[layerIndex]?.[i] ?? 0;
-          const color = activation > 0.5 ? "green" : "black";
 
           return (
             <circle
@@ -21,13 +18,13 @@ export const MLPGraph: React.FC<Props> = ({ layers, activations }) => {
               cx={x}
               cy={y}
               r="10"
-              fill={color}
+              fill="black"
               stroke="gray"
               strokeWidth="1"
             />
           );
-        });
-      })}
+        })
+      )}
     </svg>
   );
 };

--- a/src/pages/Playground.tsx
+++ b/src/pages/Playground.tsx
@@ -90,9 +90,7 @@ export default function Playground() {
 
       {model && (
         <>
-          {structure.length > 0 && (
-            <MLPGraph layers={[64, ...structure]} activations={undefined} />
-          )}
+          {structure.length > 0 && <MLPGraph />}
           <ModelStoragePanel />
         </>
       )}


### PR DESCRIPTION
## Summary
- remove props from `MLPGraph` and read layer info from zustand store
- adjust `Playground` to render `MLPGraph` without props

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_684566840cb883258988abe507d67172