### PR TITLE
Load digit dataset from store

### DIFF
--- a/src/pages/Playground.tsx
+++ b/src/pages/Playground.tsx
@@ -11,11 +11,6 @@ import { MLPGraph } from "../components/MLPGraph";
 import { createModel } from "../lib/model";
 import { extractLayerStructure } from "../lib/extractLayerStructure"; // à créer si souhaité
 
-interface DigitSample {
-  pixels: number[]; // 64 valeurs normalisées (0..1)
-  label: number; // chiffre entre 0 et 9
-}
-
 export default function Playground() {
   const model = useMLPStore((s) => s.model);
   const setModel = useMLPStore((s) => s.setModel);
@@ -30,34 +25,6 @@ export default function Playground() {
 
   const trainData = useMLPStore((s) => s.trainData);
   const testData = useMLPStore((s) => s.testData);
-  const setTrainData = useMLPStore((s) => s.setTrainData);
-  const setTestData = useMLPStore((s) => s.setTestData);
-
-  // Charger les données (par ex depuis digits_8x8.json)
-  useEffect(() => {
-    fetch("/digits_8x8.json")
-      .then((res) => res.json())
-      .then((data: DigitSample[]) => {
-        const shuffled = data.sort(() => Math.random() - 0.5);
-        const split = Math.floor(shuffled.length * 0.8);
-
-        const oneHot = (label: number) =>
-          Array.from({ length: 10 }, (_, i) => (i === label ? 1 : 0));
-
-        const train = shuffled.slice(0, split);
-        const test = shuffled.slice(split);
-
-        setTrainData({
-          xs: tf.tensor2d(train.map((d) => d.pixels)),
-          ys: tf.tensor2d(train.map((d) => oneHot(d.label))),
-        });
-        setTestData({
-          xs: tf.tensor2d(test.map((d) => d.pixels)),
-          ys: tf.tensor2d(test.map((d) => oneHot(d.label))),
-        });
-      });
-  }, []);
-
   useEffect(() => {
     const m = createModel(layers);
     m.predict(tf.zeros([1, 64]));

--- a/src/stores/useMLPStore.ts
+++ b/src/stores/useMLPStore.ts
@@ -19,6 +19,8 @@ interface MLPStore {
   testData: { xs: tf.Tensor; ys: tf.Tensor } | null;
   training: boolean;
   trainingHistory: TrainingHistory;
+  /** Load the digit dataset and prepare tensors */
+  loadData: () => Promise<void>;
   setModel: (model: tf.LayersModel) => void;
   setLayers: (layers: number[]) => void;
   setStructure: (structure: number[]) => void;
@@ -31,61 +33,92 @@ interface MLPStore {
   resetAll: () => void;
 }
 
-export const useMLPStore = create<MLPStore>((set) => ({
-  model: null,
-  layers: [32, 16],
-  structure: [],
-  pixels: [],
-  trainData: null,
-  testData: null,
-  training: false,
-  trainingHistory: {
-    epochs: [],
-    loss: [],
-    valLoss: [],
-    accuracy: [],
-    valAccuracy: [],
-  },
-  setModel: (model) => set({ model }),
-  setLayers: (layers) => set({ layers }),
-  setStructure: (structure) => set({ structure }),
-  setPixels: (pixels) => set({ pixels }),
-  setTrainData: (data) => set({ trainData: data }),
-  setTestData: (data) => set({ testData: data }),
-  setTraining: (v) => set({ training: v }),
-  resetHistory: () =>
-    set({
-      trainingHistory: {
-        epochs: [],
-        loss: [],
-        valLoss: [],
-        accuracy: [],
-        valAccuracy: [],
-      },
-    }),
-  updateHistory: (epoch, logs) =>
-    set((state) => ({
-      trainingHistory: {
-        epochs: [...state.trainingHistory.epochs, epoch + 1],
-        loss: [...state.trainingHistory.loss, logs.loss ?? 0],
-        valLoss: [...state.trainingHistory.valLoss, logs.val_loss ?? 0],
-        accuracy: [...state.trainingHistory.accuracy, logs.acc ?? 0],
-        valAccuracy: [...state.trainingHistory.valAccuracy, logs.val_acc ?? 0],
-      },
-    })),
-  resetAll: () =>
-    set({
-      model: null,
-      layers: [32, 16],
-      structure: [],
-      pixels: [],
-      training: false,
-      trainingHistory: {
-        epochs: [],
-        loss: [],
-        valLoss: [],
-        accuracy: [],
-        valAccuracy: [],
-      },
-    }),
-}));
+export const useMLPStore = create<MLPStore>((set) => {
+  const store: MLPStore = {
+    model: null,
+    layers: [32, 16],
+    structure: [],
+    pixels: [],
+    trainData: null,
+    testData: null,
+    training: false,
+    trainingHistory: {
+      epochs: [],
+      loss: [],
+      valLoss: [],
+      accuracy: [],
+      valAccuracy: [],
+    },
+    loadData: async () => {
+      const res = await fetch("/digits_8x8.json");
+      const data: { pixels: number[]; label: number }[] = await res.json();
+
+      const shuffled = data.sort(() => Math.random() - 0.5);
+      const split = Math.floor(shuffled.length * 0.8);
+
+      const oneHot = (label: number) =>
+        Array.from({ length: 10 }, (_, i) => (i === label ? 1 : 0));
+
+      const train = shuffled.slice(0, split);
+      const test = shuffled.slice(split);
+
+      set({
+        trainData: {
+          xs: tf.tensor2d(train.map((d) => d.pixels)),
+          ys: tf.tensor2d(train.map((d) => oneHot(d.label))),
+        },
+        testData: {
+          xs: tf.tensor2d(test.map((d) => d.pixels)),
+          ys: tf.tensor2d(test.map((d) => oneHot(d.label))),
+        },
+      });
+    },
+    setModel: (model) => set({ model }),
+    setLayers: (layers) => set({ layers }),
+    setStructure: (structure) => set({ structure }),
+    setPixels: (pixels) => set({ pixels }),
+    setTrainData: (data) => set({ trainData: data }),
+    setTestData: (data) => set({ testData: data }),
+    setTraining: (v) => set({ training: v }),
+    resetHistory: () =>
+      set({
+        trainingHistory: {
+          epochs: [],
+          loss: [],
+          valLoss: [],
+          accuracy: [],
+          valAccuracy: [],
+        },
+      }),
+    updateHistory: (epoch, logs) =>
+      set((state) => ({
+        trainingHistory: {
+          epochs: [...state.trainingHistory.epochs, epoch + 1],
+          loss: [...state.trainingHistory.loss, logs.loss ?? 0],
+          valLoss: [...state.trainingHistory.valLoss, logs.val_loss ?? 0],
+          accuracy: [...state.trainingHistory.accuracy, logs.acc ?? 0],
+          valAccuracy: [...state.trainingHistory.valAccuracy, logs.val_acc ?? 0],
+        },
+      })),
+    resetAll: () =>
+      set({
+        model: null,
+        layers: [32, 16],
+        structure: [],
+        pixels: [],
+        training: false,
+        trainingHistory: {
+          epochs: [],
+          loss: [],
+          valLoss: [],
+          accuracy: [],
+          valAccuracy: [],
+        },
+      }),
+  };
+
+  // automatically load the dataset once the store is created
+  void store.loadData();
+
+  return store;
+});


### PR DESCRIPTION
## Summary
- let the zustand store load digits_8x8.json
- drop dataset loading effect from the Playground page

## Testing
- `pnpm lint` *(fails: Cannot find package '@eslint/js')*
- `pnpm build` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68456aa483b88325a52cf71d8479b83a