### PR TITLE
Model creation handled by store

### DIFF
--- a/src/pages/Playground.tsx
+++ b/src/pages/Playground.tsx
@@ -1,6 +1,4 @@
 import { ModelStoragePanel } from "../components/ModelStoragePanel";
-import { useEffect } from "react";
-import * as tf from "@tensorflow/tfjs";
 import { useMLPStore } from "../stores/useMLPStore";
 import { CanvasInput } from "../components/CanvasInput";
 import { ModelConfigurator } from "../components/ModelConfigurator";
@@ -8,37 +6,20 @@ import { PredictPanel } from "../components/PredictPanel";
 import { TrainingPanel } from "../components/TrainingPanel";
 import { TrainingChart } from "../components/TrainingChart";
 import { MLPGraph } from "../components/MLPGraph";
-import { createModel } from "../lib/model";
-import { extractLayerStructure } from "../lib/extractLayerStructure"; // à créer si souhaité
 
 export default function Playground() {
   const model = useMLPStore((s) => s.model);
-  const setModel = useMLPStore((s) => s.setModel);
-  const layers = useMLPStore((s) => s.layers);
   const training = useMLPStore((s) => s.training);
   const trainingHistory = useMLPStore((s) => s.trainingHistory);
-  const resetHistory = useMLPStore((s) => s.resetHistory);
   const resetAll = useMLPStore((s) => s.resetAll);
 
   const structure = useMLPStore((s) => s.structure);
-  const setStructure = useMLPStore((s) => s.setStructure);
 
   const trainData = useMLPStore((s) => s.trainData);
   const testData = useMLPStore((s) => s.testData);
-  useEffect(() => {
-    const m = createModel(layers);
-    m.predict(tf.zeros([1, 64]));
-    setModel(m);
-    setStructure(extractLayerStructure(m));
-    resetHistory();
-  }, [layers, setModel, resetHistory]);
 
   const handleReset = () => {
     resetAll();
-    const newModel = createModel([32, 16]);
-    newModel.predict(tf.zeros([1, 64]));
-    setModel(newModel);
-    setStructure(extractLayerStructure(newModel));
   };
 
   return (


### PR DESCRIPTION
## Summary
- move model initialization logic into the zustand store
- simplify Playground page

## Testing
- `pnpm lint` *(fails: Cannot find package '@eslint/js')*
- `pnpm build` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_68456dda9ba483259ace14858b7f88f3