### PR TITLE
Add images gallery page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import Home from "./pages/Home";
 import Playground from "./pages/Playground";
 import Doc from "./pages/Doc";
 import Board from "./pages/Board";
+import Images from "./pages/Images";
 
 export default function App() {
   return (
@@ -17,6 +18,9 @@ export default function App() {
         <Link to="/board" className="hover:underline">
           Board
         </Link>
+        <Link to="/images" className="hover:underline">
+          Images
+        </Link>
         <Link to="/doc" className="hover:underline">
           Documentation
         </Link>
@@ -26,6 +30,7 @@ export default function App() {
           <Route path="/" element={<Home />} />
           <Route path="/playground" element={<Playground />} />
           <Route path="/board" element={<Board />} />
+          <Route path="/images" element={<Images />} />
           <Route path="/doc" element={<Doc />} />
         </Routes>
       </main>

--- a/src/components/DigitImage.tsx
+++ b/src/components/DigitImage.tsx
@@ -1,0 +1,37 @@
+import { useEffect, useRef } from "react";
+
+interface DigitImageProps {
+  pixels: number[];
+  size?: number;
+}
+
+export default function DigitImage({ pixels, size = 32 }: DigitImageProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    const imgData = ctx.createImageData(8, 8);
+    for (let i = 0; i < 64; i++) {
+      const val = Math.round((1 - pixels[i]) * 255);
+      const idx = i * 4;
+      imgData.data[idx] = val;
+      imgData.data[idx + 1] = val;
+      imgData.data[idx + 2] = val;
+      imgData.data[idx + 3] = 255;
+    }
+    ctx.putImageData(imgData, 0, 0);
+  }, [pixels]);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      width={8}
+      height={8}
+      style={{ width: size, height: size, imageRendering: "pixelated" }}
+    />
+  );
+}

--- a/src/components/PaginatedImages.tsx
+++ b/src/components/PaginatedImages.tsx
@@ -1,0 +1,52 @@
+import { useState } from "react";
+import DigitImage from "./DigitImage";
+
+interface ImageData {
+  pixels: number[];
+  label: number;
+}
+
+interface Props {
+  images: ImageData[];
+}
+
+export default function PaginatedImages({ images }: Props) {
+  const pageSize = 20;
+  const [page, setPage] = useState(0);
+  const pageCount = Math.ceil(images.length / pageSize);
+
+  const start = page * pageSize;
+  const current = images.slice(start, start + pageSize);
+
+  return (
+    <div className="space-y-2">
+      <div className="grid grid-cols-5 gap-2">
+        {current.map((img, idx) => (
+          <div key={start + idx} className="flex flex-col items-center">
+            <DigitImage pixels={img.pixels} />
+            <span className="text-sm">{img.label}</span>
+          </div>
+        ))}
+      </div>
+      <div className="flex justify-center items-center gap-2">
+        <button
+          className="px-2 py-1 bg-gray-200 rounded disabled:opacity-50"
+          disabled={page === 0}
+          onClick={() => setPage((p) => Math.max(0, p - 1))}
+        >
+          Précédent
+        </button>
+        <span>
+          Page {page + 1} / {pageCount}
+        </span>
+        <button
+          className="px-2 py-1 bg-gray-200 rounded disabled:opacity-50"
+          disabled={page >= pageCount - 1}
+          onClick={() => setPage((p) => Math.min(pageCount - 1, p + 1))}
+        >
+          Suivant
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Images.tsx
+++ b/src/pages/Images.tsx
@@ -1,0 +1,38 @@
+import { useEffect, useState } from "react";
+import PaginatedImages from "../components/PaginatedImages";
+
+interface ImageData {
+  pixels: number[];
+  label: number;
+}
+
+export default function Images() {
+  const [trainImages, setTrainImages] = useState<ImageData[]>([]);
+  const [valImages, setValImages] = useState<ImageData[]>([]);
+
+  useEffect(() => {
+    const load = async () => {
+      const res = await fetch("/digits_8x8.json");
+      const data: ImageData[] = await res.json();
+      const shuffled = data.sort(() => Math.random() - 0.5);
+      const split = Math.floor(shuffled.length * 0.8);
+      setTrainImages(shuffled.slice(0, split));
+      setValImages(shuffled.slice(split));
+    };
+    void load();
+  }, []);
+
+  return (
+    <div className="p-6 space-y-6">
+      <h1 className="text-xl font-bold">Images</h1>
+      <section className="space-y-2">
+        <h2 className="font-semibold">Images d\'entraînement</h2>
+        {trainImages.length > 0 && <PaginatedImages images={trainImages} />}
+      </section>
+      <section className="space-y-2">
+        <h2 className="font-semibold">Images de validation</h2>
+        {valImages.length > 0 && <PaginatedImages images={valImages} />}
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add DigitImage component to draw dataset digits
- paginate digits with PaginatedImages component
- create Images page with training and validation galleries
- link the new page in the main nav and routing

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68457703c2288325bff718b7519ecefd