### PR TITLE
Add latest training metrics and documentation links

### DIFF
--- a/src/components/TrainingChart.tsx
+++ b/src/components/TrainingChart.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Link } from "react-router-dom";
 import { Line } from "react-chartjs-2";
 import {
   Chart as ChartJS,
@@ -64,10 +65,46 @@ export const TrainingChart: React.FC = () => {
     },
   };
 
+  const lastIndex = history.epochs.length - 1;
+  const lastLoss =
+    lastIndex >= 0 ? history.loss[lastIndex].toFixed(4) : "-";
+  const lastValLoss =
+    lastIndex >= 0 ? history.valLoss[lastIndex].toFixed(4) : "-";
+  const lastAcc =
+    lastIndex >= 0 ? history.accuracy[lastIndex].toFixed(4) : "-";
+  const lastValAcc =
+    lastIndex >= 0 ? history.valAccuracy[lastIndex].toFixed(4) : "-";
+
   return (
     <div className="p-3 bg-white border">
       <h2 className="text-md font-semibold mb-2">Courbes d'entraînement</h2>
       <Line data={data} options={options} />
+      <div className="mt-2 text-sm space-x-4">
+        <span>
+          <Link to="/doc#loss" className="text-blue-700 underline">
+            loss
+          </Link>
+          : {lastLoss}
+        </span>
+        <span>
+          <Link to="/doc#val_loss" className="text-blue-700 underline">
+            val_loss
+          </Link>
+          : {lastValLoss}
+        </span>
+        <span>
+          <Link to="/doc#accuracy" className="text-blue-700 underline">
+            accuracy
+          </Link>
+          : {lastAcc}
+        </span>
+        <span>
+          <Link to="/doc#val_accuracy" className="text-blue-700 underline">
+            val_accuracy
+          </Link>
+          : {lastValAcc}
+        </span>
+      </div>
     </div>
   );
 };

--- a/src/components/TrainingChart.tsx
+++ b/src/components/TrainingChart.tsx
@@ -79,31 +79,31 @@ export const TrainingChart: React.FC = () => {
     <div className="p-3 bg-white border">
       <h2 className="text-md font-semibold mb-2">Courbes d'entraînement</h2>
       <Line data={data} options={options} />
-      <div className="mt-2 text-sm space-x-4">
-        <span>
+      <div className="mt-2 text-sm space-y-1">
+        <div>
           <Link to="/doc#loss" className="text-blue-700 underline">
             loss
           </Link>
           : {lastLoss}
-        </span>
-        <span>
+        </div>
+        <div>
           <Link to="/doc#val_loss" className="text-blue-700 underline">
             val_loss
           </Link>
           : {lastValLoss}
-        </span>
-        <span>
+        </div>
+        <div>
           <Link to="/doc#accuracy" className="text-blue-700 underline">
             accuracy
           </Link>
           : {lastAcc}
-        </span>
-        <span>
+        </div>
+        <div>
           <Link to="/doc#val_accuracy" className="text-blue-700 underline">
             val_accuracy
           </Link>
           : {lastValAcc}
-        </span>
+        </div>
       </div>
     </div>
   );

--- a/src/pages/Doc.tsx
+++ b/src/pages/Doc.tsx
@@ -1,11 +1,41 @@
 export default function Doc() {
   return (
-    <div className="p-6">
+    <div className="p-6 space-y-6">
       <h1 className="text-xl font-bold">Documentation</h1>
-      <p className="mt-2">
-        Cette page contiendra les définitions des termes comme{" "}
-        <strong>learning rate</strong>, <strong>loss</strong>, etc.
-      </p>
+
+      <section id="loss">
+        <h2 className="text-lg font-semibold">Loss</h2>
+        <p>
+          La <strong>loss</strong> représente l'erreur du modèle sur les données
+          d'entraînement. Elle diminue en général au fil des epochs si le
+          modèle apprend correctement.
+        </p>
+      </section>
+
+      <section id="val_loss">
+        <h2 className="text-lg font-semibold">Val loss</h2>
+        <p>
+          La <strong>val loss</strong> correspond à la même mesure, mais calculée sur
+          l'ensemble de validation afin d'évaluer la généralisation du modèle.
+        </p>
+      </section>
+
+      <section id="accuracy">
+        <h2 className="text-lg font-semibold">Accuracy</h2>
+        <p>
+          L'<strong>accuracy</strong> indique la proportion de prédictions
+          correctes sur les données d'entraînement.
+        </p>
+      </section>
+
+      <section id="val_accuracy">
+        <h2 className="text-lg font-semibold">Val accuracy</h2>
+        <p>
+          La <strong>val accuracy</strong> est l'accuracy calculée sur les données
+          de validation. Elle permet de vérifier le comportement du modèle sur
+          des exemples qu'il n'a pas vus pendant l'entraînement.
+        </p>
+      </section>
     </div>
   );
 }

--- a/src/pages/Doc.tsx
+++ b/src/pages/Doc.tsx
@@ -13,7 +13,7 @@ export default function Doc() {
       </section>
 
       <section id="val_loss">
-        <h2 className="text-lg font-semibold">Val loss</h2>
+        <h2 className="text-lg font-semibold">Val loss</h2>
         <p>
           La <strong>val loss</strong> correspond à la même mesure, mais calculée sur
           l'ensemble de validation afin d'évaluer la généralisation du modèle.
@@ -29,7 +29,7 @@ export default function Doc() {
       </section>
 
       <section id="val_accuracy">
-        <h2 className="text-lg font-semibold">Val accuracy</h2>
+        <h2 className="text-lg font-semibold">Val accuracy</h2>
         <p>
           La <strong>val accuracy</strong> est l'accuracy calculée sur les données
           de validation. Elle permet de vérifier le comportement du modèle sur


### PR DESCRIPTION
## Summary
- show latest loss and accuracy values in `TrainingChart`
- add sections defining loss, val loss, accuracy and val accuracy in documentation

## Testing
- `pnpm lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68457d4340008325bbf32fa5302c21cd