### PR TITLE
Add orientation toggle to MLPGraph

### DIFF
--- a/src/components/MLPGraph.tsx
+++ b/src/components/MLPGraph.tsx
@@ -1,30 +1,57 @@
-import React from "react";
+import React, { useState } from "react";
 import { useMLPStore } from "../stores/useMLPStore";
 
 export const MLPGraph: React.FC = () => {
   const structure = useMLPStore((s) => s.structure);
   const layers = [64, ...structure];
+  const [orientation, setOrientation] = useState<"vertical" | "horizontal">(
+    "vertical",
+  );
+
+  const width = orientation === "vertical" ? layers.length * 120 + 200 : 600;
+  const height = orientation === "vertical" ? 400 : layers.length * 120 + 200;
+
+  const toggle = () =>
+    setOrientation((o) => (o === "vertical" ? "horizontal" : "vertical"));
 
   return (
-    <svg viewBox="0 0 600 400" className="w-full h-96 bg-white">
-      {layers.map((count, layerIndex) =>
-        Array.from({ length: count }).map((_, i) => {
-          const x = 100 + layerIndex * 120;
-          const y = count > 1 ? 50 + (i * 300) / (count - 1) : 200;
+    <div className="space-y-2">
+      <button onClick={toggle} className="px-2 py-1 bg-gray-200 rounded">
+        {orientation === "vertical" ? "Vue horizontale" : "Vue verticale"}
+      </button>
+      <svg
+        viewBox={`0 0 ${width} ${height}`}
+        className="w-full h-96 bg-white"
+      >
+        {layers.map((count, layerIndex) =>
+          Array.from({ length: count }).map((_, i) => {
+            const x =
+              orientation === "vertical"
+                ? 100 + layerIndex * 120
+                : count > 1
+                  ? 50 + (i * (width - 100)) / (count - 1)
+                  : width / 2;
+            const y =
+              orientation === "vertical"
+                ? count > 1
+                  ? 50 + (i * (height - 100)) / (count - 1)
+                  : height / 2
+                : 100 + layerIndex * 120;
 
-          return (
-            <circle
-              key={`${layerIndex}-${i}`}
-              cx={x}
-              cy={y}
-              r="10"
-              fill="black"
-              stroke="gray"
-              strokeWidth="1"
-            />
-          );
-        })
-      )}
-    </svg>
+            return (
+              <circle
+                key={`${layerIndex}-${i}`}
+                cx={x}
+                cy={y}
+                r="10"
+                fill="black"
+                stroke="gray"
+                strokeWidth="1"
+              />
+            );
+          })
+        )}
+      </svg>
+    </div>
   );
 };


### PR DESCRIPTION
## Summary
- add a button in `MLPGraph` to toggle orientation
- support vertical and horizontal network display

## Testing
- `pnpm lint`
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_684581f1f4f483258c2b2ffd23472af5