### PR TITLE
Add epoch history display and reset button

### DIFF
--- a/src/components/TrainingChart.tsx
+++ b/src/components/TrainingChart.tsx
@@ -104,6 +104,9 @@ export const TrainingChart: React.FC = () => {
           </Link>
           : {lastValAcc}
         </div>
+        <div>
+          <Link to="/doc#epoch" className="text-blue-700 underline">epochs</Link>: {history.epochs.length}
+        </div>
       </div>
     </div>
   );

--- a/src/components/TrainingPanel.tsx
+++ b/src/components/TrainingPanel.tsx
@@ -13,6 +13,8 @@ export const TrainingPanel: React.FC = () => {
   const training = useMLPStore((s) => s.training);
   const setTraining = useMLPStore((s) => s.setTraining);
   const updateHistory = useMLPStore((s) => s.updateHistory);
+  const reinitializeModel = useMLPStore((s) => s.reinitializeModel);
+  const history = useMLPStore((s) => s.trainingHistory);
 
   const startTraining = async () => {
     if (!model || !trainData || !testData) return;
@@ -82,6 +84,16 @@ export const TrainingPanel: React.FC = () => {
       >
         {training ? "Entraînement en cours..." : "Lancer l'entraînement"}
       </button>
+      <button
+        onClick={reinitializeModel}
+        disabled={training}
+        className="mt-2 ml-2 px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700 disabled:opacity-50"
+      >
+        Réinitialiser le modèle
+      </button>
+      {history.epochs.length > 0 && (
+        <p className="text-sm mt-2">Epochs effectuées : {history.epochs.join(", ")}</p>
+      )}
     </div>
   );
 };

--- a/src/pages/Doc.tsx
+++ b/src/pages/Doc.tsx
@@ -36,6 +36,16 @@ export default function Doc() {
           des exemples qu'il n'a pas vus pendant l'entraînement.
         </p>
       </section>
+
+      <section id="epoch">
+        <h2 className="text-lg font-semibold">Epoch</h2>
+        <p>
+          Une <strong>epoch</strong> correspond à un passage complet sur l'ensemble
+          des données d'entraînement. Le nombre total d'epochs indique combien de
+          fois le modèle a vu toutes les données depuis la dernière
+          réinitialisation.
+        </p>
+      </section>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- allow resetting model weights with `reinitializeModel`
- show epochs completed in TrainingPanel
- display number of epochs in TrainingChart with documentation link
- document epoch concept

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6845834922108325ad2108b680d3f329