### PR TITLE
Refactor store to use layer info directly

### DIFF
--- a/src/components/MLPGraph.tsx
+++ b/src/components/MLPGraph.tsx
@@ -2,8 +2,8 @@ import React, { useState } from "react";
 import { useMLPStore } from "../stores/useMLPStore";
 
 export const MLPGraph: React.FC = () => {
-  const structure = useMLPStore((s) => s.structure);
-  const layers = [64, ...structure];
+  const hiddenLayers = useMLPStore((s) => s.layers);
+  const layers = [64, ...hiddenLayers, 10];
   const [orientation, setOrientation] = useState<"vertical" | "horizontal">(
     "vertical"
   );

--- a/src/pages/Playground.tsx
+++ b/src/pages/Playground.tsx
@@ -13,7 +13,7 @@ export default function Playground() {
   const trainingHistory = useMLPStore((s) => s.trainingHistory);
   const resetAll = useMLPStore((s) => s.resetAll);
 
-  const structure = useMLPStore((s) => s.structure);
+  const layers = useMLPStore((s) => s.layers);
 
   const trainData = useMLPStore((s) => s.trainData);
   const testData = useMLPStore((s) => s.testData);
@@ -38,7 +38,7 @@ export default function Playground() {
 
       {model && (
         <>
-          {structure.length > 0 && <MLPGraph />}
+          {layers.length > 0 && <MLPGraph />}
           <ModelStoragePanel />
         </>
       )}


### PR DESCRIPTION
## Summary
- simplify `useMLPStore` by removing `structure`
- adapt `MLPGraph` and `Playground` to derive layers from store

## Testing
- `pnpm lint` *(fails: Cannot find module '@eslint/js')*
- `pnpm build` *(fails: module resolution errors)*

------
https://chatgpt.com/codex/tasks/task_e_684597a999a483258290c9451cc22333