### PR TITLE
Add doc links for training params

### DIFF
--- a/src/components/TrainingPanel.tsx
+++ b/src/components/TrainingPanel.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { Link } from "react-router-dom";
 import * as tf from "@tensorflow/tfjs";
 import { useMLPStore } from "../stores/useMLPStore";
 
@@ -45,7 +46,9 @@ export const TrainingPanel: React.FC = () => {
       <h2 className="text-lg font-semibold">Entraînement du modèle</h2>
       <div className="grid grid-cols-2 gap-4">
         <label className="text-sm">
-          Learning rate
+          <Link to="/doc#learning_rate" className="text-blue-700 underline">
+            Learning rate
+          </Link>
           <input
             type="number"
             step="0.001"
@@ -56,7 +59,9 @@ export const TrainingPanel: React.FC = () => {
           />
         </label>
         <label className="text-sm">
-          Epochs
+          <Link to="/doc#epoch" className="text-blue-700 underline">
+            Epochs
+          </Link>
           <input
             type="number"
             min="1"
@@ -66,7 +71,9 @@ export const TrainingPanel: React.FC = () => {
           />
         </label>
         <label className="text-sm">
-          Batch size
+          <Link to="/doc#batch_size" className="text-blue-700 underline">
+            Batch size
+          </Link>
           <input
             type="number"
             min="1"

--- a/src/pages/Doc.tsx
+++ b/src/pages/Doc.tsx
@@ -1,22 +1,23 @@
 export default function Doc() {
   return (
-    <div className="p-6 space-y-6">
+    <div className="space-y-6 p-6">
       <h1 className="text-xl font-bold">Documentation</h1>
 
       <section id="loss">
         <h2 className="text-lg font-semibold">Loss</h2>
         <p>
           La <strong>loss</strong> représente l'erreur du modèle sur les données
-          d'entraînement. Elle diminue en général au fil des epochs si le
-          modèle apprend correctement.
+          d'entraînement. Elle diminue en général au fil des epochs si le modèle
+          apprend correctement.
         </p>
       </section>
 
       <section id="val_loss">
         <h2 className="text-lg font-semibold">Val loss</h2>
         <p>
-          La <strong>val loss</strong> correspond à la même mesure, mais calculée sur
-          l'ensemble de validation afin d'évaluer la généralisation du modèle.
+          La <strong>val loss</strong> correspond à la même mesure, mais
+          calculée sur l'ensemble de validation afin d'évaluer la généralisation
+          du modèle.
         </p>
       </section>
 
@@ -31,19 +32,41 @@ export default function Doc() {
       <section id="val_accuracy">
         <h2 className="text-lg font-semibold">Val accuracy</h2>
         <p>
-          La <strong>val accuracy</strong> est l'accuracy calculée sur les données
-          de validation. Elle permet de vérifier le comportement du modèle sur
-          des exemples qu'il n'a pas vus pendant l'entraînement.
+          La <strong>val accuracy</strong> est l'accuracy calculée sur les
+          données de validation. Elle permet de vérifier le comportement du
+          modèle sur des exemples qu'il n'a pas vus pendant l'entraînement.
         </p>
       </section>
 
       <section id="epoch">
         <h2 className="text-lg font-semibold">Epoch</h2>
         <p>
-          Une <strong>epoch</strong> correspond à un passage complet sur l'ensemble
-          des données d'entraînement. Le nombre total d'epochs indique combien de
-          fois le modèle a vu toutes les données depuis la dernière
-          réinitialisation.
+          Une <strong>epoch</strong> correspond à un passage complet sur
+          l'ensemble des données d'entraînement. Le nombre total d'epochs
+          indique combien de fois le modèle a vu toutes les données depuis la
+          dernière réinitialisation.
+        </p>
+      </section>
+
+      <section id="learning_rate">
+        <h2 className="text-lg font-semibold">Learning rate</h2>
+        <p>
+          Le <strong>learning rate</strong> ou taux d'apprentissage contrôle la
+          vitesse à laquelle les poids du réseau sont ajustés pendant
+          l'entraînement. Une valeur trop élevée peut faire diverger
+          l'apprentissage alors qu'une valeur trop faible peut le rendre très
+          lent.
+        </p>
+      </section>
+
+      <section id="batch_size">
+        <h2 className="text-lg font-semibold">Batch size</h2>
+        <p>
+          Le <strong>batch size</strong> correspond au nombre d'exemples traités
+          avant de mettre à jour les poids du modèle. Des valeurs petites
+          donnent des mises à jour plus fréquentes mais bruitées, tandis qu'une
+          valeur plus grande nécessite plus de mémoire mais offre une estimation
+          plus stable du gradient.
         </p>
       </section>
     </div>


### PR DESCRIPTION
## Summary
- link training parameter labels to the glossary page
- document `learning rate` and `batch size` terms

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6845dace9be88325bab9a25c1906044d