### PR TITLE
Fix dataset fetch path

### DIFF
--- a/src/pages/Images.tsx
+++ b/src/pages/Images.tsx
@@ -12,7 +12,9 @@ export default function Images() {
 
   useEffect(() => {
     const load = async () => {
-      const res = await fetch("/digits_8x8.json");
+      const res = await fetch(
+        new URL("digits_8x8.json", import.meta.env.BASE_URL).toString(),
+      );
       const data: ImageData[] = await res.json();
       const shuffled = data.sort(() => Math.random() - 0.5);
       const split = Math.floor(shuffled.length * 0.8);

--- a/src/stores/useMLPStore.ts
+++ b/src/stores/useMLPStore.ts
@@ -57,7 +57,9 @@ export const useMLPStore = create<MLPStore>((set, get) => {
     training: false,
     trainingHistory: emptyHistory(),
     loadData: async () => {
-      const res = await fetch("/digits_8x8.json");
+      const res = await fetch(
+        new URL("digits_8x8.json", import.meta.env.BASE_URL).toString(),
+      );
       const data: { pixels: number[]; label: number }[] = await res.json();
 
       const shuffled = data.sort(() => Math.random() - 0.5);


### PR DESCRIPTION
## Summary
- handle base URL for dataset in Images page and store
- run lint and build

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6845dda8dca88325896d694148f00d06