### PR TITLE
Use zustand store to supply digit images

### DIFF
--- a/src/pages/Images.tsx
+++ b/src/pages/Images.tsx
@@ -1,26 +1,9 @@
-import { useEffect, useState } from "react";
 import PaginatedImages from "../components/PaginatedImages";
-
-interface ImageData {
-  pixels: number[];
-  label: number;
-}
+import { useImageStore } from "../stores/useImageStore";
 
 export default function Images() {
-  const [trainImages, setTrainImages] = useState<ImageData[]>([]);
-  const [valImages, setValImages] = useState<ImageData[]>([]);
-
-  useEffect(() => {
-    const load = async () => {
-      const res = await fetch("/digits_8x8.json");
-      const data: ImageData[] = await res.json();
-      const shuffled = data.sort(() => Math.random() - 0.5);
-      const split = Math.floor(shuffled.length * 0.8);
-      setTrainImages(shuffled.slice(0, split));
-      setValImages(shuffled.slice(split));
-    };
-    void load();
-  }, []);
+  const trainImages = useImageStore((s) => s.trainImages);
+  const valImages = useImageStore((s) => s.valImages);
 
   return (
     <div className="p-6 space-y-6">

--- a/src/stores/useImageStore.ts
+++ b/src/stores/useImageStore.ts
@@ -1,0 +1,33 @@
+import { create } from "zustand";
+
+export interface ImageData {
+  pixels: number[];
+  label: number;
+}
+
+interface ImageStore {
+  trainImages: ImageData[];
+  valImages: ImageData[];
+  loadImages: () => Promise<void>;
+}
+
+export const useImageStore = create<ImageStore>((set) => {
+  const store: ImageStore = {
+    trainImages: [],
+    valImages: [],
+    loadImages: async () => {
+      const res = await fetch("/digits_8x8.json");
+      const data: ImageData[] = await res.json();
+      const shuffled = data.sort(() => Math.random() - 0.5);
+      const split = Math.floor(shuffled.length * 0.8);
+      set({
+        trainImages: shuffled.slice(0, split),
+        valImages: shuffled.slice(split),
+      });
+    },
+  };
+
+  void store.loadImages();
+
+  return store;
+});


### PR DESCRIPTION
## Summary
- add an `useImageStore` zustand store that loads the digits dataset
- update `Images` page to read images from the store

## Testing
- `pnpm lint`
- `pnpm exec tsc -b`


------
https://chatgpt.com/codex/tasks/task_e_6846911371f4832582164958630250c4