### PR TITLE
feat: add responsive header

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,30 +1,15 @@
-import { HashRouter as Router, Routes, Route, Link } from "react-router-dom";
+import { HashRouter as Router, Routes, Route } from "react-router-dom";
 import Home from "./pages/Home";
 import Doc from "./pages/Doc";
 import Board from "./pages/Board";
 import Images from "./pages/Images";
 import Test from "./pages/Test";
+import Header from "./components/Header";
 
 export default function App() {
   return (
     <Router>
-      <nav className="flex gap-4 bg-white p-4 font-medium text-blue-700 shadow">
-        <Link to="/" className="hover:underline">
-          Accueil
-        </Link>
-        <Link to="/board" className="hover:underline">
-          Board
-        </Link>
-        <Link to="/images" className="hover:underline">
-          Images
-        </Link>
-        <Link to="/doc" className="hover:underline">
-          Documentation
-        </Link>
-        <Link to="/test" className="hover:underline">
-          Test
-        </Link>
-      </nav>
+      <Header />
       <main className="min-h-screen bg-gray-50">
         <Routes>
           <Route path="/" element={<Home />} />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,55 @@
+import { Link } from "react-router-dom";
+import { useState } from "react";
+
+export default function Header() {
+  const [open, setOpen] = useState(false);
+
+  const toggle = () => setOpen(!open);
+  const close = () => setOpen(false);
+
+  const links = (
+    <>
+      <Link to="/" className="hover:underline" onClick={close}>
+        Accueil
+      </Link>
+      <Link to="/board" className="hover:underline" onClick={close}>
+        Board
+      </Link>
+      <Link to="/images" className="hover:underline" onClick={close}>
+        Images
+      </Link>
+      <Link to="/doc" className="hover:underline" onClick={close}>
+        Documentation
+      </Link>
+      <Link to="/test" className="hover:underline" onClick={close}>
+        Test
+      </Link>
+    </>
+  );
+
+  return (
+    <nav className="bg-white p-4 font-medium text-blue-700 shadow">
+      <div className="flex items-center justify-between">
+        <div className="hidden gap-4 md:flex">{links}</div>
+        <button className="md:hidden" onClick={toggle} aria-label="Toggle menu">
+          <svg
+            className="h-6 w-6"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            strokeWidth={2}
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M4 6h16M4 12h16M4 18h16"
+            />
+          </svg>
+        </button>
+      </div>
+      {open && (
+        <div className="mt-2 flex flex-col gap-2 md:hidden">{links}</div>
+      )}
+    </nav>
+  );
+}


### PR DESCRIPTION
## Summary
- extract the `<nav>` into a new `Header` component
- show navigation links as a hamburger menu on small screens
- use the new `Header` in `App`

## Testing
- `pnpm run lint`
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_6846a045fa2483258a696169402bf7f1