### PR TITLE
feat: improve mobile menu interactions

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -9,19 +9,39 @@ export default function Header() {
 
   const links = (
     <>
-      <Link to="/" className="hover:underline" onClick={close}>
+      <Link
+        to="/"
+        className="px-4 py-2 hover:underline md:px-0 md:py-0"
+        onClick={close}
+      >
         Accueil
       </Link>
-      <Link to="/board" className="hover:underline" onClick={close}>
+      <Link
+        to="/board"
+        className="px-4 py-2 hover:underline md:px-0 md:py-0"
+        onClick={close}
+      >
         Board
       </Link>
-      <Link to="/images" className="hover:underline" onClick={close}>
+      <Link
+        to="/images"
+        className="px-4 py-2 hover:underline md:px-0 md:py-0"
+        onClick={close}
+      >
         Images
       </Link>
-      <Link to="/doc" className="hover:underline" onClick={close}>
+      <Link
+        to="/doc"
+        className="px-4 py-2 hover:underline md:px-0 md:py-0"
+        onClick={close}
+      >
         Documentation
       </Link>
-      <Link to="/test" className="hover:underline" onClick={close}>
+      <Link
+        to="/test"
+        className="px-4 py-2 hover:underline md:px-0 md:py-0"
+        onClick={close}
+      >
         Test
       </Link>
     </>
@@ -33,7 +53,7 @@ export default function Header() {
         <div className="hidden gap-4 md:flex">{links}</div>
         <button className="md:hidden" onClick={toggle} aria-label="Toggle menu">
           <svg
-            className="h-6 w-6"
+            className="h-6 w-6 cursor-pointer"
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"


### PR DESCRIPTION
## Summary
- enable pointer cursor on the mobile menu bars icon
- add padding for each mobile menu item so the responsive menu breathes better

## Testing
- `pnpm run lint`
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_6846adbff7688325977cad68ef0e6b36