### PR TITLE
Add Training page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import Doc from "./pages/Doc";
 import Board from "./pages/Board";
 import Images from "./pages/Images";
 import Test from "./pages/Test";
+import Training from "./pages/Training";
 import Header from "./components/Header";
 
 export default function App() {
@@ -17,6 +18,7 @@ export default function App() {
           <Route path="/images" element={<Images />} />
           <Route path="/doc" element={<Doc />} />
           <Route path="/test" element={<Test />} />
+          <Route path="/training" element={<Training />} />
         </Routes>
       </main>
     </Router>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -24,6 +24,13 @@ export default function Header() {
         Board
       </Link>
       <Link
+        to="/training"
+        className="px-4 py-2 hover:underline md:px-0 md:py-0"
+        onClick={close}
+      >
+        Training
+      </Link>
+      <Link
         to="/images"
         className="px-4 py-2 hover:underline md:px-0 md:py-0"
         onClick={close}

--- a/src/pages/Training.tsx
+++ b/src/pages/Training.tsx
@@ -1,0 +1,15 @@
+import { TrainingChart } from "../components/TrainingChart";
+import { TrainingPanel } from "../components/TrainingPanel";
+
+export default function Training() {
+  return (
+    <div className="flex flex-col items-center gap-4 p-4">
+      <div className="w-full max-w-md">
+        <TrainingPanel />
+      </div>
+      <div className="w-full max-w-2xl">
+        <TrainingChart />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create new Training page combining `TrainingPanel` and `TrainingChart`
- register Training route and link
- update navigation menu

## Testing
- `pnpm exec prettier --write src/App.tsx src/components/Header.tsx src/pages/Training.tsx`

------
https://chatgpt.com/codex/tasks/task_e_6846b4dbae94832585cb7128f9058bc2