### PR TITLE
Add weight visualization toggle

### DIFF
--- a/src/components/MLPGraph.tsx
+++ b/src/components/MLPGraph.tsx
@@ -11,6 +11,9 @@ export const MLPGraph: React.FC = () => {
     "vertical",
   );
   const [activations, setActivations] = useState<number[][]>([]);
+  const [weights, setWeights] = useState<number[][][]>([]);
+  const [maxWeight, setMaxWeight] = useState(1);
+  const [showWeights, setShowWeights] = useState(false);
 
   const width = orientation === "vertical" ? layers.length * 120 + 200 : 600;
   const height = orientation === "vertical" ? 400 : layers.length * 120 + 200;
@@ -31,6 +34,46 @@ export const MLPGraph: React.FC = () => {
     });
     setActivations(acts);
   }, [model, pixels]);
+
+  useEffect(() => {
+    if (!model) {
+      setWeights([]);
+      setMaxWeight(1);
+      return;
+    }
+    const ws: number[][][] = [];
+    tf.tidy(() => {
+      for (const layer of model.layers) {
+        const kernel = layer.getWeights()[0];
+        if (!kernel) {
+          ws.push([]);
+          continue;
+        }
+        ws.push(kernel.arraySync() as number[][]);
+      }
+    });
+    const maxW = Math.max(0.000001, ...ws.flat(2).map((v) => Math.abs(v)));
+    setMaxWeight(maxW);
+    setWeights(ws);
+  }, [model]);
+
+  const neuronPositions = layers.map((count, layerIndex) =>
+    Array.from({ length: count }).map((_, i) => {
+      const x =
+        orientation === "vertical"
+          ? 100 + layerIndex * 120
+          : count > 1
+            ? 50 + (i * (width - 100)) / (count - 1)
+            : width / 2;
+      const y =
+        orientation === "vertical"
+          ? count > 1
+            ? 50 + (i * (height - 100)) / (count - 1)
+            : height / 2
+          : 100 + layerIndex * 120;
+      return { x, y };
+    }),
+  );
 
   return (
     <div className="flex flex-col gap-2 bg-white">
@@ -61,22 +104,50 @@ export const MLPGraph: React.FC = () => {
             Horizontal
           </button>
         </div>
+        <div className="ml-2 inline-flex rounded border">
+          <button
+            onClick={() => setShowWeights((s) => !s)}
+            className={[
+              "px-2 py-1 text-sm",
+              showWeights
+                ? "bg-gray-600 text-white"
+                : "bg-gray-200 text-gray-700",
+              "rounded",
+            ].join(" ")}
+          >
+            {showWeights ? "Hide weights" : "Show weights"}
+          </button>
+        </div>
       </div>
       <svg viewBox={`0 0 ${width} ${height}`} className="flex-grow bg-white">
+        {showWeights &&
+          weights.map((matrix, layerIndex) => {
+            const fromLayer = neuronPositions[layerIndex];
+            const toLayer = neuronPositions[layerIndex + 1];
+            if (!fromLayer || !toLayer) return null;
+            return matrix.map((row, i) =>
+              row.map((w, j) => {
+                const thickness = (Math.abs(w) / maxWeight) * 3;
+                if (thickness <= 0) return null;
+                const from = fromLayer[i];
+                const to = toLayer[j];
+                return (
+                  <line
+                    key={`w-${layerIndex}-${i}-${j}`}
+                    x1={from.x}
+                    y1={from.y}
+                    x2={to.x}
+                    y2={to.y}
+                    stroke="rgba(0,0,0,0.5)"
+                    strokeWidth={thickness}
+                  />
+                );
+              }),
+            );
+          })}
         {layers.map((count, layerIndex) =>
           Array.from({ length: count }).map((_, i) => {
-            const x =
-              orientation === "vertical"
-                ? 100 + layerIndex * 120
-                : count > 1
-                  ? 50 + (i * (width - 100)) / (count - 1)
-                  : width / 2;
-            const y =
-              orientation === "vertical"
-                ? count > 1
-                  ? 50 + (i * (height - 100)) / (count - 1)
-                  : height / 2
-                : 100 + layerIndex * 120;
+            const { x, y } = neuronPositions[layerIndex][i];
 
             const v = activations[layerIndex]?.[i] ?? 0;
             const intensity = Math.max(0, Math.min(1, v));


### PR DESCRIPTION
## Summary
- add toggle button to show or hide weight connections
- render connection lines with thickness proportional to weight magnitude

## Testing
- `pnpm run lint`
- `pnpm exec prettier --write src/components/MLPGraph.tsx`

------
https://chatgpt.com/codex/tasks/task_e_6846ba362a6c8325a8c3dee3271551ca