### PR TITLE
feat(header): highlight active menu

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router-dom";
+import { NavLink } from "react-router-dom";
 import { useState } from "react";
 
 export default function Header() {
@@ -9,48 +9,66 @@ export default function Header() {
 
   const links = (
     <>
-      <Link
+      <NavLink
         to="/"
-        className="px-4 py-2 hover:underline md:px-0 md:py-0"
+        className={({ isActive }) =>
+          "px-4 py-2 hover:underline md:px-0 md:py-0" +
+          (isActive ? " font-bold underline" : "")
+        }
         onClick={close}
       >
         Accueil
-      </Link>
-      <Link
+      </NavLink>
+      <NavLink
         to="/board"
-        className="px-4 py-2 hover:underline md:px-0 md:py-0"
+        className={({ isActive }) =>
+          "px-4 py-2 hover:underline md:px-0 md:py-0" +
+          (isActive ? " font-bold underline" : "")
+        }
         onClick={close}
       >
         Board
-      </Link>
-      <Link
+      </NavLink>
+      <NavLink
         to="/training"
-        className="px-4 py-2 hover:underline md:px-0 md:py-0"
+        className={({ isActive }) =>
+          "px-4 py-2 hover:underline md:px-0 md:py-0" +
+          (isActive ? " font-bold underline" : "")
+        }
         onClick={close}
       >
         Training
-      </Link>
-      <Link
+      </NavLink>
+      <NavLink
         to="/images"
-        className="px-4 py-2 hover:underline md:px-0 md:py-0"
+        className={({ isActive }) =>
+          "px-4 py-2 hover:underline md:px-0 md:py-0" +
+          (isActive ? " font-bold underline" : "")
+        }
         onClick={close}
       >
         Images
-      </Link>
-      <Link
+      </NavLink>
+      <NavLink
         to="/doc"
-        className="px-4 py-2 hover:underline md:px-0 md:py-0"
+        className={({ isActive }) =>
+          "px-4 py-2 hover:underline md:px-0 md:py-0" +
+          (isActive ? " font-bold underline" : "")
+        }
         onClick={close}
       >
         Documentation
-      </Link>
-      <Link
+      </NavLink>
+      <NavLink
         to="/test"
-        className="px-4 py-2 hover:underline md:px-0 md:py-0"
+        className={({ isActive }) =>
+          "px-4 py-2 hover:underline md:px-0 md:py-0" +
+          (isActive ? " font-bold underline" : "")
+        }
         onClick={close}
       >
         Test
-      </Link>
+      </NavLink>
     </>
   );
 


### PR DESCRIPTION
## Summary
- highlight active menu in the header with NavLink

## Testing
- `pnpm exec prettier src/components/Header.tsx --check`

------
https://chatgpt.com/codex/tasks/task_e_6846ce376e7c83259d54259e721757ed