### PR TITLE
Fix weight rendering after removing layers

### DIFF
--- a/src/components/MLPGraph.tsx
+++ b/src/components/MLPGraph.tsx
@@ -131,6 +131,7 @@ export const MLPGraph: React.FC = () => {
                 if (thickness <= 0) return null;
                 const from = fromLayer[i];
                 const to = toLayer[j];
+                if (!from || !to) return null;
                 return (
                   <line
                     key={`w-${layerIndex}-${i}-${j}`}


### PR DESCRIPTION
## Summary
- handle undefined neuron positions while rendering weights in the graph

## Testing
- `pnpm run lint`
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_6846dee17c348325869073dc9cd3c244