### PR TITLE
Add spinner on training

### DIFF
--- a/src/components/TrainingPanel.tsx
+++ b/src/components/TrainingPanel.tsx
@@ -88,7 +88,33 @@ export const TrainingPanel: React.FC = () => {
         disabled={training}
         className="mt-2 cursor-pointer rounded bg-green-600 px-4 py-1 text-white hover:bg-green-700 disabled:opacity-50"
       >
-        {training ? "Entraînement en cours..." : "Lancer l'entraînement"}
+        {training ? (
+          <span className="flex items-center justify-center gap-1">
+            Entraînement en cours
+            <svg
+              className="h-4 w-4 animate-spin"
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+            >
+              <circle
+                className="opacity-25"
+                cx="12"
+                cy="12"
+                r="10"
+                stroke="currentColor"
+                strokeWidth="4"
+              />
+              <path
+                className="opacity-75"
+                fill="currentColor"
+                d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4z"
+              />
+            </svg>
+          </span>
+        ) : (
+          "Lancer l'entraînement"
+        )}
       </button>
       <button
         onClick={reinitializeModel}


### PR DESCRIPTION
## Summary
- show spinner instead of trailing dots when training model

## Testing
- `pnpm run format`

------
https://chatgpt.com/codex/tasks/task_e_68470e84a8c883258861d5ce35db5d27