### PR TITLE
Add title to mobile header

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -83,6 +83,7 @@ export default function Header() {
   return (
     <nav className="relative bg-white p-4 font-medium text-blue-700 shadow">
       <div className="flex items-center justify-between">
+        <span className="text-lg font-bold md:hidden">MLP Visualizer</span>
         <div className="hidden gap-4 md:flex">{links}</div>
         <button className="md:hidden" onClick={toggle} aria-label="Toggle menu">
           <svg


### PR DESCRIPTION
## Summary
- show app title on the left of the mobile header

## Testing
- `pnpm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68470ef09e588325aa9f470855f1627e