### PR TITLE
Update header links

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -10,16 +10,6 @@ export default function Header() {
   const links = (
     <>
       <NavLink
-        to="/"
-        className={({ isActive }) =>
-          "px-4 py-2 hover:underline md:px-0 md:py-0" +
-          (isActive ? " font-bold underline" : "")
-        }
-        onClick={close}
-      >
-        Accueil
-      </NavLink>
-      <NavLink
         to="/images"
         className={({ isActive }) =>
           "px-4 py-2 hover:underline md:px-0 md:py-0" +
@@ -83,7 +73,13 @@ export default function Header() {
   return (
     <nav className="relative bg-white p-4 font-medium text-blue-700 shadow">
       <div className="flex items-center justify-between">
-        <span className="text-lg font-bold md:hidden">MLP Visualizer</span>
+        <NavLink
+          to="/"
+          className="text-lg font-bold hover:underline"
+          onClick={close}
+        >
+          MLP Visualizer
+        </NavLink>
         <div className="hidden gap-4 md:flex">{links}</div>
         <button className="md:hidden" onClick={toggle} aria-label="Toggle menu">
           <svg


### PR DESCRIPTION
## Summary
- add home link on header title and display it on desktop
- drop "Accueil" from the menu

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68471171d2808325983d0c3eb841bcca