### PR TITLE
Fix spinner stutter during training

### DIFF
--- a/src/components/TrainingPanel.tsx
+++ b/src/components/TrainingPanel.tsx
@@ -31,8 +31,14 @@ export const TrainingPanel: React.FC = () => {
       batchSize,
       validationData: [testData.xs, testData.ys],
       callbacks: {
+        onBatchEnd: async () => {
+          // Yield to the browser so UI updates like the spinner stay smooth.
+          await tf.nextFrame();
+        },
         onEpochEnd: async (epoch, logs) => {
           updateHistory(epoch, logs as tf.Logs);
+          // Yield after each epoch as well.
+          await tf.nextFrame();
         },
         onTrainEnd: async () => {
           setTraining(false);


### PR DESCRIPTION
## Summary
- keep the UI responsive by yielding on batch and epoch ends

## Testing
- `pnpm run format`

------
https://chatgpt.com/codex/tasks/task_e_684715c715d88325994ee79c0d319863