### PR TITLE
Split zustand MLP store into slices

### DIFF
--- a/src/stores/mlp/dataSlice.ts
+++ b/src/stores/mlp/dataSlice.ts
@@ -1,0 +1,44 @@
+import type { StateCreator } from "zustand";
+import * as tf from "@tensorflow/tfjs";
+import type { DataSlice, MLPStore } from "./types";
+
+export const createDataSlice: StateCreator<MLPStore, [], [], DataSlice> = (
+  set,
+  _get,
+  _store,
+) => {
+  void _get;
+  void _store;
+  return {
+    pixels: [],
+    trainData: null,
+    testData: null,
+    loadData: async () => {
+      const res = await fetch("./digits_8x8.json");
+      const data: { pixels: number[]; label: number }[] = await res.json();
+
+      const shuffled = data.sort(() => Math.random() - 0.5);
+      const split = Math.floor(shuffled.length * 0.8);
+
+      const oneHot = (label: number) =>
+        Array.from({ length: 10 }, (_, i) => (i === label ? 1 : 0));
+
+      const train = shuffled.slice(0, split);
+      const test = shuffled.slice(split);
+
+      set({
+        trainData: {
+          xs: tf.tensor2d(train.map((d) => d.pixels)),
+          ys: tf.tensor2d(train.map((d) => oneHot(d.label))),
+        },
+        testData: {
+          xs: tf.tensor2d(test.map((d) => d.pixels)),
+          ys: tf.tensor2d(test.map((d) => oneHot(d.label))),
+        },
+      });
+    },
+    setPixels: (pixels) => set({ pixels }),
+    setTrainData: (data) => set({ trainData: data }),
+    setTestData: (data) => set({ testData: data }),
+  };
+};

--- a/src/stores/mlp/modelSlice.ts
+++ b/src/stores/mlp/modelSlice.ts
@@ -1,0 +1,56 @@
+import type { StateCreator } from "zustand";
+import * as tf from "@tensorflow/tfjs";
+import { createModel } from "../../lib/model";
+import { extractLayerStructure } from "../../lib/extractLayerStructure";
+import type { ModelSlice, MLPStore } from "./types";
+import { emptyHistory } from "./trainingSlice";
+
+const defaultLayers = [32, 16];
+const defaultModel = createModel(defaultLayers);
+defaultModel.predict(tf.zeros([1, 64]));
+
+export const createModelSlice: StateCreator<MLPStore, [], [], ModelSlice> = (
+  set,
+  get,
+  _store,
+) => {
+  void _store;
+  return {
+    model: defaultModel,
+    layers: defaultLayers,
+    setModel: (model) => {
+      const structure = extractLayerStructure(model);
+      set({ model, layers: structure.slice(0, -1) });
+    },
+    setLayers: (layers) => {
+      const m = createModel(layers);
+      m.predict(tf.zeros([1, 64]));
+      set({
+        layers,
+        model: m,
+        trainingHistory: emptyHistory(),
+      });
+    },
+    reinitializeModel: () => {
+      const layers = get().layers;
+      const m = createModel(layers);
+      m.predict(tf.zeros([1, 64]));
+      set({
+        model: m,
+        training: false,
+        trainingHistory: emptyHistory(),
+      });
+    },
+    resetAll: () => {
+      const m = createModel(defaultLayers);
+      m.predict(tf.zeros([1, 64]));
+      set({
+        model: m,
+        layers: defaultLayers,
+        pixels: [],
+        training: false,
+        trainingHistory: emptyHistory(),
+      });
+    },
+  };
+};

--- a/src/stores/mlp/trainingSlice.ts
+++ b/src/stores/mlp/trainingSlice.ts
@@ -1,0 +1,40 @@
+import type { StateCreator } from "zustand";
+import type { Logs } from "@tensorflow/tfjs";
+import type { TrainingSlice, TrainingHistory, MLPStore } from "./types";
+
+export const emptyHistory = (): TrainingHistory => ({
+  epochs: [],
+  loss: [],
+  valLoss: [],
+  accuracy: [],
+  valAccuracy: [],
+});
+
+export const createTrainingSlice: StateCreator<
+  MLPStore,
+  [],
+  [],
+  TrainingSlice
+> = (set, _get, _store): TrainingSlice => {
+  void _get;
+  void _store;
+  return {
+    training: false,
+    trainingHistory: emptyHistory(),
+    setTraining: (v) => set({ training: v }),
+    resetHistory: () => set({ trainingHistory: emptyHistory() }),
+    updateHistory: (epoch, logs: Logs) =>
+      set((state) => ({
+        trainingHistory: {
+          epochs: [...state.trainingHistory.epochs, epoch + 1],
+          loss: [...state.trainingHistory.loss, logs.loss ?? 0],
+          valLoss: [...state.trainingHistory.valLoss, logs.val_loss ?? 0],
+          accuracy: [...state.trainingHistory.accuracy, logs.acc ?? 0],
+          valAccuracy: [
+            ...state.trainingHistory.valAccuracy,
+            logs.val_acc ?? 0,
+          ],
+        },
+      })),
+  };
+};

--- a/src/stores/mlp/types.ts
+++ b/src/stores/mlp/types.ts
@@ -1,0 +1,39 @@
+import * as tf from "@tensorflow/tfjs";
+
+export interface TrainingHistory {
+  epochs: number[];
+  loss: number[];
+  valLoss: number[];
+  accuracy: number[];
+  valAccuracy: number[];
+}
+
+export interface DataSlice {
+  pixels: number[];
+  trainData: { xs: tf.Tensor; ys: tf.Tensor } | null;
+  testData: { xs: tf.Tensor; ys: tf.Tensor } | null;
+  loadData: () => Promise<void>;
+  setPixels: (pixels: number[]) => void;
+  setTrainData: (data: { xs: tf.Tensor; ys: tf.Tensor } | null) => void;
+  setTestData: (data: { xs: tf.Tensor; ys: tf.Tensor } | null) => void;
+}
+
+export interface ModelSlice {
+  model: tf.LayersModel | null;
+  /** hidden layer sizes of the current model */
+  layers: number[];
+  setModel: (model: tf.LayersModel) => void;
+  setLayers: (layers: number[]) => void;
+  reinitializeModel: () => void;
+  resetAll: () => void;
+}
+
+export interface TrainingSlice {
+  training: boolean;
+  trainingHistory: TrainingHistory;
+  setTraining: (v: boolean) => void;
+  resetHistory: () => void;
+  updateHistory: (epoch: number, logs: tf.Logs) => void;
+}
+
+export type MLPStore = DataSlice & ModelSlice & TrainingSlice;

--- a/src/stores/useMLPStore.ts
+++ b/src/stores/useMLPStore.ts
@@ -1,142 +1,17 @@
 import { create } from "zustand";
-import * as tf from "@tensorflow/tfjs";
-import { createModel } from "../lib/model";
-import { extractLayerStructure } from "../lib/extractLayerStructure";
+import { createDataSlice } from "./mlp/dataSlice";
+import { createModelSlice } from "./mlp/modelSlice";
+import { createTrainingSlice } from "./mlp/trainingSlice";
+import type { MLPStore } from "./mlp/types";
 
-export interface TrainingHistory {
-  epochs: number[];
-  loss: number[];
-  valLoss: number[];
-  accuracy: number[];
-  valAccuracy: number[];
-}
-
-interface MLPStore {
-  model: tf.LayersModel | null;
-  /** hidden layer sizes of the current model */
-  layers: number[];
-  pixels: number[];
-  trainData: { xs: tf.Tensor; ys: tf.Tensor } | null;
-  testData: { xs: tf.Tensor; ys: tf.Tensor } | null;
-  training: boolean;
-  trainingHistory: TrainingHistory;
-  /** Load the digit dataset and prepare tensors */
-  loadData: () => Promise<void>;
-  setModel: (model: tf.LayersModel) => void;
-  setLayers: (layers: number[]) => void;
-  setPixels: (pixels: number[]) => void;
-  setTrainData: (data: { xs: tf.Tensor; ys: tf.Tensor } | null) => void;
-  setTestData: (data: { xs: tf.Tensor; ys: tf.Tensor } | null) => void;
-  setTraining: (v: boolean) => void;
-  /** Reinitialize weights and biases while keeping the same architecture */
-  reinitializeModel: () => void;
-  resetHistory: () => void;
-  updateHistory: (epoch: number, logs: tf.Logs) => void;
-  resetAll: () => void;
-}
-
-export const useMLPStore = create<MLPStore>((set, get) => {
-  const emptyHistory = (): TrainingHistory => ({
-    epochs: [],
-    loss: [],
-    valLoss: [],
-    accuracy: [],
-    valAccuracy: [],
-  });
-
-  const defaultLayers = [32, 16];
-  const defaultModel = createModel(defaultLayers);
-  defaultModel.predict(tf.zeros([1, 64]));
-
-  const store: MLPStore = {
-    model: defaultModel,
-    layers: defaultLayers,
-    pixels: [],
-    trainData: null,
-    testData: null,
-    training: false,
-    trainingHistory: emptyHistory(),
-    loadData: async () => {
-      const res = await fetch("./digits_8x8.json");
-      const data: { pixels: number[]; label: number }[] = await res.json();
-
-      const shuffled = data.sort(() => Math.random() - 0.5);
-      const split = Math.floor(shuffled.length * 0.8);
-
-      const oneHot = (label: number) =>
-        Array.from({ length: 10 }, (_, i) => (i === label ? 1 : 0));
-
-      const train = shuffled.slice(0, split);
-      const test = shuffled.slice(split);
-
-      set({
-        trainData: {
-          xs: tf.tensor2d(train.map((d) => d.pixels)),
-          ys: tf.tensor2d(train.map((d) => oneHot(d.label))),
-        },
-        testData: {
-          xs: tf.tensor2d(test.map((d) => d.pixels)),
-          ys: tf.tensor2d(test.map((d) => oneHot(d.label))),
-        },
-      });
-    },
-    setModel: (model) => {
-      const structure = extractLayerStructure(model);
-      set({ model, layers: structure.slice(0, -1) });
-    },
-    setLayers: (layers) => {
-      const m = createModel(layers);
-      m.predict(tf.zeros([1, 64]));
-      set({
-        layers,
-        model: m,
-        trainingHistory: emptyHistory(),
-      });
-    },
-    setPixels: (pixels) => set({ pixels }),
-    setTrainData: (data) => set({ trainData: data }),
-    setTestData: (data) => set({ testData: data }),
-    setTraining: (v) => set({ training: v }),
-    reinitializeModel: () => {
-      const layers = get().layers;
-      const m = createModel(layers);
-      m.predict(tf.zeros([1, 64]));
-      set({
-        model: m,
-        training: false,
-        trainingHistory: emptyHistory(),
-      });
-    },
-    resetHistory: () => set({ trainingHistory: emptyHistory() }),
-    updateHistory: (epoch, logs) =>
-      set((state) => ({
-        trainingHistory: {
-          epochs: [...state.trainingHistory.epochs, epoch + 1],
-          loss: [...state.trainingHistory.loss, logs.loss ?? 0],
-          valLoss: [...state.trainingHistory.valLoss, logs.val_loss ?? 0],
-          accuracy: [...state.trainingHistory.accuracy, logs.acc ?? 0],
-          valAccuracy: [
-            ...state.trainingHistory.valAccuracy,
-            logs.val_acc ?? 0,
-          ],
-        },
-      })),
-    resetAll: () => {
-      const defaultLayers = [32, 16];
-      const m = createModel(defaultLayers);
-      m.predict(tf.zeros([1, 64]));
-      set({
-        model: m,
-        layers: defaultLayers,
-        pixels: [],
-        training: false,
-        trainingHistory: emptyHistory(),
-      });
-    },
+export const useMLPStore = create<MLPStore>((set, get, store) => {
+  const slices: MLPStore = {
+    ...createDataSlice(set, get, store),
+    ...createModelSlice(set, get, store),
+    ...createTrainingSlice(set, get, store),
   };
 
-  // automatically load the dataset
-  void store.loadData();
+  void slices.loadData();
 
-  return store;
+  return slices;
 });


### PR DESCRIPTION
## Summary
- refactor MLP store to use separate zustand slices
- keep main store that composes `data`, `model` and `training` slices

## Testing
- `pnpm run format`
- `pnpm run lint`
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_685bab4d3a448325b10a88e7257e0e48