### PR TITLE
feat(graph): draw inverted triangles for input neurons

### DIFF
--- a/src/components/MLPGraph.tsx
+++ b/src/components/MLPGraph.tsx
@@ -198,7 +198,15 @@ export const MLPGraph: React.FC = () => {
               ? "red"
               : `rgb(0, ${Math.round(intensity * 255)}, 0)`;
 
-            return layerIndex === layers.length - 1 ? (
+            return layerIndex === 0 ? (
+              <polygon
+                key={`${layerIndex}-${i}`}
+                points={`${x - 4},${y - 4} ${x + 4},${y - 4} ${x},${y + 4}`}
+                fill={color}
+                stroke="gray"
+                strokeWidth="1"
+              />
+            ) : layerIndex === layers.length - 1 ? (
               <polygon
                 key={`${layerIndex}-${i}`}
                 points={`${x - 4},${y + 4} ${x + 4},${y + 4} ${x},${y - 4}`}


### PR DESCRIPTION
## Summary
- draw input neurons as downward triangles

## Testing
- `pnpm run lint`
- `pnpm run format`


------
https://chatgpt.com/codex/tasks/task_e_686be6fc5f38832589294b7e14033a8b